### PR TITLE
Prevent tljh issues with numpy 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 rdkit
 ipywidgets
 py3Dmol
-numpy
+numpy<2
 debtcollector
 jupyterlab_myst
 dftd3


### PR DESCRIPTION
The current tljh instance doesn't yet support numpy 2.0, so we need numpy<2 to keep things working for now